### PR TITLE
Update getting-started.md

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -54,7 +54,7 @@ Steps:
 4. Select"Web application" as the Application type
 5. Name it "OpenRelik Localhost" or to whatever you want (it doesn't matter)
 6. In "Authorized redirect URIs" click "+ ADD URI"
-7. Enter "http://localhost:8000/auth"
+7. Enter "http://localhost:8710/auth"
 8. Click "SAVE"
 
 On the right you will have details for your new credentials. The important ones are:


### PR DESCRIPTION
Had issues at this step and debugging revealed that the Oauth login was attempting to redirect to `http://localhost:8710/auth` instead of `http://localhost:8000/auth` . 

Made this change to the client credentials in GCP and everything worked. 