### PR TITLE
Update worker registry

### DIFF
--- a/astro/src/data/workers.json
+++ b/astro/src/data/workers.json
@@ -7,7 +7,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-analyzer-logs",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-analyzer-logs",
       "github_stars": 1
     },
@@ -18,7 +18,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-bulkextractor",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-bulkextractor",
       "github_stars": 1
     },
@@ -35,7 +35,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-capa",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-capa",
       "github_stars": 1
     },
@@ -46,7 +46,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-chromecreds",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-chromecreds",
       "github_stars": 1
     },
@@ -57,7 +57,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-entropy",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-entropy",
       "github_stars": 1
     },
@@ -68,7 +68,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-analyzer-config",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-analyzer-config",
       "github_stars": 1
     },
@@ -79,7 +79,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-dfindexeddb",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-dfindexeddb",
       "github_stars": 1
     },
@@ -90,7 +90,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-extraction",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-extraction",
       "github_stars": 1
     },
@@ -107,7 +107,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-floss",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-floss",
       "github_stars": 1
     },
@@ -118,7 +118,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-grep",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-grep",
       "github_stars": 1
     },
@@ -129,7 +129,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-llm",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-llm",
       "github_stars": 1
     },
@@ -151,7 +151,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-strings",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-strings",
       "github_stars": 1
     },
@@ -168,7 +168,7 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-timesketch",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-timesketch",
       "github_stars": 1
     },
@@ -300,7 +300,7 @@
       "repository": "openrelik-contrib/openrelik-worker-hayabusa",
       "license": "Apache License 2.0",
       "owner": "OpenRelik Contrib",
-      "updated_at": "2026-02-10",
+      "updated_at": "2026-03-06",
       "url": "https://github.com/openrelik-contrib/openrelik-worker-hayabusa",
       "github_stars": 3
     },
@@ -362,8 +362,25 @@
       "repository": "dig-sec/openrelik-worker-clamav",
       "license": "N/A",
       "owner": "Pabi",
-      "updated_at": "2026-02-24",
+      "updated_at": "2026-03-03",
       "url": "https://github.com/dig-sec/openrelik-worker-clamav",
+      "github_stars": 0
+    },
+    {
+      "display_name": "openrelik-worker-ghidra",
+      "description": "Secure headless Ghidra analysis worker for deterministic JSON artifacts.",
+      "tools": [
+        {
+          "display_name": "Ghidra",
+          "description": "Software reverse engineering suite for binary analysis and decompilation.",
+          "url": "https://ghidra-sre.org/"
+        }
+      ],
+      "repository": "dig-sec/openrelik-worker-ghidra",
+      "license": "N/A",
+      "owner": "Pabi",
+      "updated_at": "2026-03-05",
+      "url": "https://github.com/dig-sec/openrelik-worker-ghidra",
       "github_stars": 0
     },
     {

--- a/astro/src/data/workers.json
+++ b/astro/src/data/workers.json
@@ -418,6 +418,23 @@
       "github_stars": 0
     },
     {
+      "display_name": "SFTP Upload",
+      "description": "Upload files to a host using SFTP. Can be used with SOF-ELK® for example.",
+      "tools": [
+        {
+          "display_name": "Paramiko",
+          "description": "A Python implementation of SSHv2.",
+          "url": "https://www.paramiko.org/"
+        }
+      ],
+      "repository": "PeterSufliarsky/openrelik-worker-sftp",
+      "license": "MIT License",
+      "owner": "Peter Šufliarsky",
+      "updated_at": "2026-03-06",
+      "url": "https://github.com/PeterSufliarsky/openrelik-worker-sftp",
+      "github_stars": 0
+    },
+    {
       "display_name": "Thor Lite",
       "description": "Scanner for attacker tools and activity",
       "tools": [],

--- a/astro/src/data/workers.json
+++ b/astro/src/data/workers.json
@@ -7,9 +7,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-analyzer-logs",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-analyzer-logs",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Bulkextractor",
@@ -18,9 +18,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-bulkextractor",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-bulkextractor",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Capa",
@@ -35,9 +35,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-capa",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-capa",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Chrome Credentials Analyser",
@@ -46,9 +46,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-chromecreds",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-chromecreds",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Compute byte entropy for files.",
@@ -57,9 +57,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-entropy",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-entropy",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Config file analyzer",
@@ -68,9 +68,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-analyzer-config",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-analyzer-config",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "dfIndexeddb",
@@ -79,9 +79,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-dfindexeddb",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-dfindexeddb",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "File Extraction",
@@ -90,9 +90,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-extraction",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-extraction",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "FLARE Obfuscated String Solver (FLOSS)",
@@ -107,9 +107,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-floss",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-floss",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Grep",
@@ -118,9 +118,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-grep",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-grep",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "LLM Prompter",
@@ -129,9 +129,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-llm",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-llm",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Plaso",
@@ -140,7 +140,7 @@
       "repository": "openrelik/openrelik-worker-plaso",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-02-27",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-worker-plaso",
       "github_stars": 6
     },
@@ -151,9 +151,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-strings",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-strings",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "Timesketch",
@@ -168,9 +168,9 @@
       "repository": "openrelik/openrelik-workers/workers/openrelik-worker-timesketch",
       "license": "Apache License 2.0",
       "owner": "OpenRelik",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-14",
       "url": "https://github.com/openrelik/openrelik-workers/tree/main/workers/openrelik-worker-timesketch",
-      "github_stars": 1
+      "github_stars": 2
     },
     {
       "display_name": "AmCache-EvilHunter",
@@ -300,7 +300,7 @@
       "repository": "openrelik-contrib/openrelik-worker-hayabusa",
       "license": "Apache License 2.0",
       "owner": "OpenRelik Contrib",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-12",
       "url": "https://github.com/openrelik-contrib/openrelik-worker-hayabusa",
       "github_stars": 3
     },
@@ -320,6 +320,28 @@
       "updated_at": "2025-11-26",
       "url": "https://github.com/AbdullahAlzeid/Openrelik-worker-hindsight",
       "github_stars": 1
+    },
+    {
+      "display_name": "KStrike & UAL Timeliner",
+      "description": "Worker for OpenRelik providing UAL parsing with KStrike and forensic timeline generation with UAL Timeliner.",
+      "tools": [
+        {
+          "display_name": "KStrike",
+          "description": "Stand-alone parser for User Access Logging from Server 2012 and newer systems",
+          "url": "https://github.com/brimorlabs/KStrike"
+        },
+        {
+          "display_name": "UAL Timeliner",
+          "description": "Forensic timeline generator for Windows User Access Logging databases",
+          "url": "https://github.com/kev365/ual-timeliner"
+        }
+      ],
+      "repository": "kev365/openrelik-worker-kstrike",
+      "license": "Apache License 2.0",
+      "owner": "kev365",
+      "updated_at": "2026-04-14",
+      "url": "https://github.com/kev365/openrelik-worker-kstrike",
+      "github_stars": 2
     },
     {
       "display_name": "Kusto Ingest Worker",
@@ -384,21 +406,26 @@
       "github_stars": 0
     },
     {
-      "display_name": "openrelik-worker-kstrike",
-      "description": "Worker for OpenRelik to add User Access Log parsing with Brian Moran's KStrike tool.",
+      "display_name": "OpenSearch",
+      "description": "Index workflow output into OpenSearch or upload to Timesketch.",
       "tools": [
         {
-          "display_name": "KStrike",
-          "description": "Stand-alone parser for User Access Logging from Server 2012 and newer systems",
-          "url": "https://github.com/brimorlabs/KStrike"
+          "display_name": "OpenSearch",
+          "description": "Open-source search and analytics suite that makes it easy to ingest, search, visualize, and analyze data.",
+          "url": "https://opensearch.org/"
+        },
+        {
+          "display_name": "Timesketch",
+          "description": "Open-source tool for collaborative forensic timeline analysis.",
+          "url": "https://timesketch.org/"
         }
       ],
-      "repository": "kev365/openrelik-worker-kstrike",
+      "repository": "kev365/openrelik-worker-opensearch",
       "license": "Apache License 2.0",
       "owner": "kev365",
-      "updated_at": "2025-08-02",
-      "url": "https://github.com/kev365/openrelik-worker-kstrike",
-      "github_stars": 0
+      "updated_at": "2026-04-14",
+      "url": "https://github.com/kev365/openrelik-worker-opensearch",
+      "github_stars": 1
     },
     {
       "display_name": "RECmd Worker",
@@ -430,7 +457,7 @@
       "repository": "PeterSufliarsky/openrelik-worker-sftp",
       "license": "MIT License",
       "owner": "Peter Šufliarsky",
-      "updated_at": "2026-03-06",
+      "updated_at": "2026-05-04",
       "url": "https://github.com/PeterSufliarsky/openrelik-worker-sftp",
       "github_stars": 0
     },
@@ -441,9 +468,9 @@
       "repository": "NextronSystems/openrelik-worker-thor-lite",
       "license": "Apache License 2.0",
       "owner": "Nextron Systems GmbH",
-      "updated_at": "2026-03-03",
+      "updated_at": "2026-04-24",
       "url": "https://github.com/NextronSystems/openrelik-worker-thor-lite",
-      "github_stars": 9
+      "github_stars": 10
     },
     {
       "display_name": "Txt File to CSV Worker",


### PR DESCRIPTION
### Summary
Updated the worker directory data configuration to synchronize repository metrics and register new integration schemas for KStrike, UAL Timeliner, and OpenSearch tools.

### Technical Details
*   **Worker Registry Config:** Refreshed timestamp and star metrics for existing tools in `astro/src/data/workers.json` to synchronize local metadata with upstream repository states.
*   **Worker Registry Config:** Added the `KStrike & UAL Timeliner` worker entry to register User Access Logging parsing integrations in the system catalog.
*   **Worker Registry Config:** Swapped the legacy `openrelik-worker-kstrike` block with the `OpenSearch` schema definition to declare the search indexer integration.%